### PR TITLE
Update arguments when calling sendWhenReady

### DIFF
--- a/patches/swipe-to-navigate.js
+++ b/patches/swipe-to-navigate.js
@@ -38,7 +38,7 @@ define([
         window._win.addListener(event, function (_, command) {
             let selectedAction = commandMappedAction[command];
             if (selectedAction != null) {
-                window.sendWhenReady('vscode:runAction', selectedAction);
+                window.sendWhenReady('vscode:runAction', null, selectedAction);
             }
 
         });


### PR DESCRIPTION
In a [recent change](https://github.com/microsoft/vscode/commit/7bbf45c14e8058fd8bedcd14ff6bb727e44db8a7#diff-ce055d098d503f8b3309d514fd97e4a84da4515e21ee102618bbb2097087ab2bR1245) to vscode the signature of `sendWhenReady` was changed, 
the second argument is now expected to be some type of Cancellation token.
This causes the event to fail since the action should now be the last argument.
Ideally this should pass `CancellationToken.None` but I couldn't figure out how to correctly import it.

Fixes #7 