### PR TITLE
Add reverse direction support for the swipe gesture.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the "swipe-to-navigate" extension will be documented in t
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 
+## [1.2.1] - 2021-06-01
+### Added
+- Add reverse direction support for the swipe gesture.
 
 ## [0.1.0] - 2019-10-17
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@
 ```jsonc
 "swipeToNavigate.action": "disabled" | "tabs" |  "grouped-tabs" | "recent-code" | "recent-files"
 ```
-
+```jsonc
+"swipeToNavigate.directionReverse": true | false
+```
 ### Examples:
 
 * Currently opened *tabs* - **default**.
 ```jsonc
 "swipeToNavigate.action": "tabs"
+"swipeToNavigate.directionReverse": false
 ```
 
 * Currently opened *tabs* in a single *group*.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "swipe-to-navigate",
     "displayName": "Swipe To Navigate",
     "description": "VSCode Extension for adding three finger swipe with various options similar to Xcode.",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publisher": "seivan",
     "repository": {
         "type": "git",
@@ -51,6 +51,11 @@
                         "Swipes navigate between recent code and files - like Xcode.",
                         "Swipes navigate between recent files."
                     ]
+                },
+                "swipeToNavigate.directionReverse": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Controls whether swipe right goes forward or backward. Default is going forward."
                 }
             }
         }

--- a/patches/swipe-to-navigate.js
+++ b/patches/swipe-to-navigate.js
@@ -23,10 +23,14 @@ define([
 
     function registerSwipe(event, config, window) {
         logger(window, "Registered Swipe Listener!");
-        let action = availableActions[config.action]
-            .map(function (action) { return 'workbench.action.' + action; })
-            .map(function (action) { return { id: action } })
-            .reduce(function (_pv, _cv, _idx, actions) { return { back: actions[0], forward: actions[1] }; });
+
+        // when reverse = true: swipe from left to right to go back;
+        let direction = config.directionReverse ? 1 : 0;
+
+        // change to avoid unnecessary loop
+        let actions = availableActions[config.action]
+            .map(function (action) { return { id: 'workbench.action.' + action } })
+        let action = { back: actions[direction], forward: actions[1 - direction] }
 
         let commandMappedAction = {
             left: action.back,
@@ -76,4 +80,3 @@ define([
 
 
 });
-


### PR DESCRIPTION
For  https://github.com/seivan/swipe-to-navigate/issues/6 & https://github.com/seivan/swipe-to-navigate/issues/10
<img width="557" alt="Screenshot 2021-06-01 at 07 55 38" src="https://user-images.githubusercontent.com/10446823/120250320-499d2480-c2b0-11eb-86be-a937ec70d899.png">


Tested on (Version: 1.56.2
Commit: 054a9295330880ed74ceaedda236253b4f39a335
Date: 2021-05-12T17:44:30.902Z (2 wks ago)
Electron: 12.0.4
Chrome: 89.0.4389.114
Node.js: 14.16.0
V8: 8.9.255.24-electron.0
OS: Darwin x64 20.4.0)
